### PR TITLE
Add pickle version option

### DIFF
--- a/s3cache/__init__.py
+++ b/s3cache/__init__.py
@@ -75,6 +75,9 @@ class AmazonS3Cache(BaseCache):
         # sanitize location by removing leading and traling slashes
         self._options['LOCATION'] = self._location.strip('/')
 
+        self._pickle_protocol = self._options.get(
+            'PICKLE_VERSION', pickle.HIGHEST_PROTOCOL)
+
         # S3BotoStorage wants lower case names
         lowercase_options = []
         for name, value in self._options.items():
@@ -133,8 +136,8 @@ class AmazonS3Cache(BaseCache):
         if timeout is None:
             timeout = self.default_timeout
 
-        content = pickle.dumps(time.time() + timeout, pickle.HIGHEST_PROTOCOL)
-        content += pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
+        content = pickle.dumps(time.time() + timeout, self._pickle_protocol)
+        content += pickle.dumps(value, self._pickle_protocol)
         return content
 
     def delete(self, key, version=None):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as file:
 
 config = {
     'name' : 'django-s3-cache',
-    'version' : '1.4.2',
+    'version' : '2.1',
     'packages' : find_packages(),
     'author' : 'Alexander Todorov',
     'author_email' : 'atodorov@MrSenko.com',


### PR DESCRIPTION
What?
=====
I added the cache option PICKLE_VERSION to specify the pickle protocol
that will be used to write content.

Why?
=====
We need to be able to use a specific pickle version when different hosts
may be using different python versions where pickle.HIGHEST_PROTOCOL is
different.