### PR TITLE
TE-38808: Upgrade django-s3-cache for compatibility with Django 5.2.10 and Python 3.10.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,31 +5,31 @@ addons:
 after_success:
 - coveralls
 before_install:
-- pip install coveralls mock
+- pip install coveralls
 - if [ -z "$_COMMAND" ]; then export _COMMAND=test; fi
-- if [ -z "$_DJANGO" ]; then export _DJANGO=2.1.4; export _DJANGO_STORAGES=1.7.1; export _BOTO=2.49.0; fi
+- if [ -z "$_DJANGO" ]; then export _DJANGO=5.2.10; export _DJANGO_STORAGES=1.14; export _BOTO3=1.26.0; fi
 env:
-- _BOTO=2.49.0 _DJANGO=1.11.17 _DJANGO_STORAGES=1.7.1
-- _BOTO=2.49.0 _DJANGO=2.0.9 _DJANGO_STORAGES=1.7.1
-- _BOTO=2.49.0 _DJANGO=2.1.4 _DJANGO_STORAGES=1.7.1
+- _BOTO3=1.26.0 _DJANGO=5.0.10 _DJANGO_STORAGES=1.14
+- _BOTO3=1.26.0 _DJANGO=5.1.5 _DJANGO_STORAGES=1.14
+- _BOTO3=1.26.0 _DJANGO=5.2.10 _DJANGO_STORAGES=1.14
 install:
 - pip install django-nose
 - pip install pylint
-- if [ -n "$_BOTO" ]; then pip install boto==$_BOTO; fi
 - if [ -n "$_BOTO3" ]; then pip install boto3==$_BOTO3; fi
 - if [ -n "$_DJANGO" ]; then pip install Django==$_DJANGO django-storages==$_DJANGO_STORAGES; fi
 language: python
 matrix:
   include:
   - env: _COMMAND=pylint
-    python: 3.6
+    python: 3.10
 notifications:
   email:
     on_failure: change
     on_success: change
 python:
-- 2.7
-- 3.6
+- "3.10"
+- "3.11"
+- "3.12"
 script:
 - make $_COMMAND
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as file:
 
 config = {
     'name' : 'django-s3-cache',
-    'version' : '2.2.6',
+    'version' : '3.0.0',
     'packages' : find_packages(),
     'author' : 'Alexander Todorov',
     'author_email' : 'atodorov@MrSenko.com',
@@ -27,10 +27,18 @@ config = {
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: Django',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
     ],
+    'python_requires': '>=3.10',
     'zip_safe' : False,
-    'install_requires' : ['boto', 'django-storages>=1.9', 'Django'],
+    'install_requires' : ['boto3>=1.26.0', 'django-storages>=1.14', 'Django>=5.2,<6.0'],
 }
 
 if (len(sys.argv) >= 2) and (sys.argv[1] == '--requires'):

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -19,7 +19,7 @@ global_settings.NOSE_ARGS = [
     '--cover-branches',
     '--cover-package=s3cache',
 ]
-global_settings.MIDDLEWARE_CLASSES = ()
+global_settings.MIDDLEWARE = ()
 global_settings.SECRET_KEY = "not-very-secret"
 
 global_settings.DATABASES = {


### PR DESCRIPTION
What?
---
Upgrade django-s3-cache for compatibility with Django 5.2.10 and Python 3.10.16.

Why?
---
To make codebase compatible with Django 5.2.10 & Python 3.10.16 Upgarde.

Ticket:
--- 
https://eptura.atlassian.net/browse/TE-38808